### PR TITLE
LPS-24343 Unable to remove form fields translations in Web Form Portlet

### DIFF
--- a/portlets/web-form-portlet/docroot/WEB-INF/src/com/liferay/webform/action/ConfigurationActionImpl.java
+++ b/portlets/web-form-portlet/docroot/WEB-INF/src/com/liferay/webform/action/ConfigurationActionImpl.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -121,24 +122,12 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 						actionRequest, "invalidValidationDefinition" + i);
 				}
 
-				for (Locale locale : fieldLabelMap.keySet()) {
-					String languageId = LocaleUtil.toLanguageId(locale);
-					String fieldLabelValue = fieldLabelMap.get(locale);
-					String fieldOptionsValue = fieldOptionsMap.get(locale);
+				updateFieldLocales("fieldLabel", fieldLabelMap, i,
+					preferences);
 
-					if (Validator.isNotNull(fieldLabelValue)) {
-						LocalizationUtil.setPreferencesValue(
-							preferences, "fieldLabel" + i, languageId,
-							fieldLabelValue);
-					}
-
-					if (Validator.isNotNull(fieldOptionsValue)) {
-						LocalizationUtil.setPreferencesValue(
-							preferences, "fieldOptions" + i, languageId,
-							fieldOptionsValue);
-					}
-				}
-
+				updateFieldLocales("fieldOptions", fieldOptionsMap, i,
+					preferences);				
+				
 				preferences.setValue("fieldType" + i, fieldType);
 				preferences.setValue(
 					"fieldOptional" + i, String.valueOf(fieldOptional));
@@ -197,7 +186,7 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 		super.processAction(portletConfig, actionRequest, actionResponse);
 	}
-
+	
 	@Override
 	public String render(
 			PortletConfig portletConfig, RenderRequest renderRequest,
@@ -211,6 +200,29 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 		}
 		else {
 			return "/configuration.jsp";
+		}
+	}
+	
+	protected void updateFieldLocales(
+			String formFieldName, Map<Locale, String> newFormFieldMap,
+			int newFormFieldIndex, PortletPreferences preferences)
+		throws Exception{
+		
+		Map<Locale, String> oldFieldLabelMap = 
+			LocalizationUtil.getLocalizationMap(
+				preferences, formFieldName + newFormFieldIndex);
+		
+		List<Locale> labelMapModifiedLocales = 
+			LocalizationUtil.getModifiedLocales(
+					oldFieldLabelMap, newFormFieldMap);
+		
+		for (Locale locale : labelMapModifiedLocales) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+			String fieldLabelValue = newFormFieldMap.get(locale);
+
+			LocalizationUtil.setPreferencesValue(
+				preferences, formFieldName + newFormFieldIndex, languageId,
+					fieldLabelValue);
 		}
 	}
 
@@ -344,5 +356,5 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 		return true;
 	}
-
+	
 }


### PR DESCRIPTION
Theses changes allow:
- Remove form fields translations
- Change the form fields order deleting previous translations
